### PR TITLE
Optimize dependent projects installation package size

### DIFF
--- a/MCL.BLS12_381.Native.targets
+++ b/MCL.BLS12_381.Native.targets
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+      <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    </PropertyGroup>
   <ItemGroup Condition="'$(SkipSecp256k1NativeLibCopy)' != 'true'">
-
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libmclbn384_256.so">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(RuntimeIdentifier)'=='linux-x64'">PreserveNewest</CopyToOutputDirectory>
       <Link>native\linux-x64\libmclbn384_256.so</Link>
       <Visible>true</Visible>
       <Pack>false</Pack>
@@ -12,7 +14,7 @@
 
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libmclbn384_256.dylib">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(RuntimeIdentifier)'=='osx-x64'">PreserveNewest</CopyToOutputDirectory>
       <Link>native\osx-x64\libmclbn384_256.dylib</Link>
       <Visible>true</Visible>
       <Pack>false</Pack>
@@ -20,7 +22,7 @@
 
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\mclbn384_256.dll">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition="'$(RuntimeIdentifier)'=='win-x64'">PreserveNewest</CopyToOutputDirectory>
       <Link>native\win-x64\mclbn384_256.dll</Link>
       <Visible>true</Visible>
       <Pack>false</Pack>


### PR DESCRIPTION
This fix allows to copy in dependant project install packets only related native libraries decreasing this packets size